### PR TITLE
Hide delete button using transparency rather than visibility

### DIFF
--- a/simple-todos.css
+++ b/simple-todos.css
@@ -75,14 +75,14 @@ ul {
   background: none;
   font-size: 1em;
   border: none;
-  visibility: hidden;
+  color: transparent;
   position: relative;
 }
 
 .delete:after {
-  visibility: visible;
   display: block;
   content: "\00D7";
+  color: black;
   position: absolute;
   top: -10px;
   left: -10px;


### PR DESCRIPTION
visibility:hidden apparently disables mouse events in Firefox, leaving the delete button rather useless!
There's a [test case here](http://codepen.io/ZackBoe/pen/Cuydk/), and the only bug report I could find was [this rather old one](https://bugzilla.mozilla.org/show_bug.cgi?id=711709).

It's also worth noting that the :after element won't display at all in IE11. (Thanks @simevidas)

I'm using Firefox Aurora 35.0a2 (2014-10-29)
